### PR TITLE
add flix to module list

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -7,5 +7,6 @@ This is a list of JavaScript modules adhering to [`fpti-js`](readme.md).
 Module | Operator | 🏳️ | First added | [`stations.all`](docs/stations-stops-regions.all.md) | [`stops.all`](docs/stations-stops-regions.all.md) | [`regions.all`](docs/stations-stops-regions.all.md) | [`stations.search`](docs/stations-stops-regions.search.md) | [`stops.search`](docs/stations-stops-regions.search.md) | [`regions.search`](docs/stations-stops-regions.search.md) | [`stations.nearby`](docs/stations-stops-regions.nearby.md) | [`stops.nearby`](docs/stations-stops-regions.nearby.md) | [`regions.nearby`](docs/stations-stops-regions.nearby.md) | [`journeys`](docs/journeys.md) | [`stopovers`](docs/stopovers.md)
 --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
 [`interrail`](https://github.com/juliuste/interrail) | [*Interrail\**](https://www.interrail.eu/) | 🇪🇺 | *2018-11-06* in `3.0.0` |  ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
+[`flix`](https://github.com/juliuste/flix) | [FlixBus (Meinfernbus) / FlixTrain](https://www.flixbus.com/) | 🇪🇺 | *2019-06-23* in `5.0.0` |  ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 
 \*Not an operator, probably still interesting though


### PR DESCRIPTION
The [`flix` module](https://github.com/juliuste/flix) is now FPTI compatible 🎉.