### PR TITLE
add slovenske-zeleznice to module list

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -10,5 +10,6 @@ Module | Operator | 🏳️ | First added | [`stations.all`](docs/stations-stops
 [`flix`](https://github.com/juliuste/flix) | [FlixBus (Meinfernbus) / FlixTrain](https://www.flixbus.com/) | 🇪🇺 | *2019-06-23* in `5.0.0` |  ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 [`korail`](https://github.com/juliuste/korail) | [Korail](https://www.letskorail.com/) | 🇰🇷 | *2019-06-23* in `2.0.0` |  ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 [`train-ose`](https://github.com/juliuste/train-ose) | [TrainOSE](https://www.trainose.gr/) | 🇬🇷 | *2019-06-23* in `1.0.0` |  ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
+[`slovenske-zeleznice`](https://github.com/juliuste/slovenske-zeleznice) | [Slovenske železnice (SŽ)](http://www.slo-zeleznice.si/) | 🇸🇮 | *2019-06-23* in `1.0.0` |  ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 
 \*Not an operator, probably still interesting though


### PR DESCRIPTION
The [`slovenske-zeleznice` module](https://github.com/juliuste/slovenske-zeleznice) is now FPTI compatible 🎉.